### PR TITLE
Fix/package & apidoc

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "boilerplate"
   ],
   "apidoc": {
-    "title": "ApiDoc pour le projet Boilerplate",
+    "name": "API Boilerplate",
+    "title": "ApiDoc | Boilerplate",
     "url": "/api",
     "sampleUrl": "http://localhost:4000/api"
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "filrouge-boilerplate-frontend",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Fix name discrepancy between front-end's package.json and package-lock.json
Add a proper header title to ApiDoc pages